### PR TITLE
fix TOCTOU and add missing error handler in db.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "shellexpand"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,10 +692,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -695,6 +719,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]

--- a/src/lib/db.rs
+++ b/src/lib/db.rs
@@ -37,9 +37,12 @@ fn get_connection(configuration: &Config) -> rusqlite::Result<Connection> {
         path.to_str().unwrap()
     );
     
-    let parent_path = path.parent().unwrap();
-    if !parent_path.exists() {
-        std::fs::create_dir_all(path.parent().unwrap()).expect("failed to create containing folders for bakfile database");
+    let parent_path = match path.parent() {
+        Some(good_path) => good_path,
+        None => { panic!("{}", anyhow::anyhow!("invalid bak.db location specified in bak config")) }
+    };
+
+    if let Ok(()) = std::fs::create_dir_all(parent_path) {
         trace!("created containing folders for bakfile database");
     }
     


### PR DESCRIPTION
note: the binary will invoke human panic by the time we release