### PR TITLE
MIT license and update CREDITS.md

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -32,4 +32,4 @@ Cam Blomquist (https://github.com/camblomquist) - Code review and consultation
 
 ### Public domain
 
-Versions of `bak` may exist which, via `rusqlite`, bundle SQLite itself, a popular database engine written in the C programming language. SQLite is in the public domain. You probably don't need this version of `bak`, which may not currently exist, because SQLite is already installed on most Unix-like systems.
+Versions of `bak` exist which, via `rusqlite`, bundle SQLite itself, a popular database engine written in the C programming language. SQLite is in the public domain.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
-Copyright 2024 ChanceNCounter
-All rights reserved while this program is being rewritten
-If this program has been released, and this document has not been replaced with the boilerplate MIT license, please alert the maintainers at https://github.com/bakfile
+Copyright © 2025 ChanceNCounter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
I'm more or less satisfied that the dependency tree has been audited well enough. This is now MIT-licensed software, as was always the plan.